### PR TITLE
Botões adicionais no leitor de PDF

### DIFF
--- a/App/views/html/leitorPdf.php
+++ b/App/views/html/leitorPdf.php
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8">
-  <title>Leitor PDF com Progresso</title>
+  <title>Leitor PDF com Navegação</title>
   <style>
     body {
       background: #222;
@@ -11,17 +11,10 @@
       text-align: center;
     }
 
-    .page-container {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin: 20px;
-    }
-
     canvas {
       border: 1px solid #555;
       background: white;
-      margin-right: 10px;
+      margin-top: 20px;
     }
 
     button {
@@ -32,24 +25,22 @@
       border-radius: 8px;
       cursor: pointer;
       transition: 0.3s;
+      margin: 5px;
     }
 
     button:hover {
       background: #0056b3;
     }
   </style>
-
-  
 </head>
 <body>
-  <h2>Visualizador de PDF com PDF.js e Progresso</h2>
+  <h2>Visualizador de PDF com Botões</h2>
   <div id="pdfContainer"></div>
 
   <!-- PDF.js CDN -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
   <script src="/TimerBook/App/views/javascript/utils.js?v=<?= time() ?>"></script>
   <script src="/TimerBook/App/views/javascript/leitor.js?v=<?= time() ?>"></script>
-
 
   <script>
     const urlParams = new URLSearchParams(window.location.search);
@@ -64,9 +55,6 @@
       carregarPdf(livro);
     }
     init();
-    
-    
-
   </script>
 </body>
 </html>


### PR DESCRIPTION
Foi feito a inserção de botões para o leitor de PDF, como por exemplo voltar para página anterior, buscar página, e foi trocado a forma de leitura do PDF de scroll para passar páginas