### PR TITLE
Meta de leitura e seus endpoints de teste

### DIFF
--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/AuthController.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/AuthController.java
@@ -36,10 +36,11 @@ public class AuthController  implements AuthControllerDocs{
             @RequestParam("username") String username,
             @RequestParam("email") String email,
             @RequestParam("password") String password,
+            @RequestParam(value = "dailyReadingGoalMinutes", required = false) Integer dailyReadingGoalMinutes,
             @RequestParam(value = "photo", required = false) MultipartFile photo
     ) {
         try {
-            RegisterRequestDTO dto = new RegisterRequestDTO(username, email, password, null);
+            RegisterRequestDTO dto = new RegisterRequestDTO(username, email, password, null, dailyReadingGoalMinutes);
 
             String message = authService.register(dto, photo);
 

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/ReadingStatsController.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/ReadingStatsController.java
@@ -2,6 +2,7 @@ package com.timerbook.TimerBook.controllers;
 
 import com.timerbook.TimerBook.controllers.docs.ReadingStatsControllerDocs;
 import com.timerbook.TimerBook.dto.ReadingStatsDTO;
+import com.timerbook.TimerBook.dto.UserReadingGoalStreakDTO;
 import com.timerbook.TimerBook.models.Reading;
 import com.timerbook.TimerBook.repository.UserRepository;
 import com.timerbook.TimerBook.services.ReadingStatsService;
@@ -70,5 +71,17 @@ public class ReadingStatsController implements ReadingStatsControllerDocs {
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(403).build();
         }
+    }
+
+    @GetMapping("/user/streak")
+    public ResponseEntity<UserReadingGoalStreakDTO> getUserGoalStreak(
+            @RequestParam(value = "start", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam(value = "end", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
+    ) {
+        Long userId = getLoggedUserId();
+        UserReadingGoalStreakDTO dto = service.getUserGoalStreak(userId, start, end);
+        return ResponseEntity.ok(dto);
     }
 }

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/UserController.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/UserController.java
@@ -1,13 +1,11 @@
 package com.timerbook.TimerBook.controllers;
 
 import com.timerbook.TimerBook.controllers.docs.UserControllerDocs;
+import com.timerbook.TimerBook.dto.UserReadingGoalRequestDTO;
+import com.timerbook.TimerBook.dto.UserReadingGoalResponseDTO;
 import com.timerbook.TimerBook.dto.UserDTO;
 import com.timerbook.TimerBook.models.User;
 import com.timerbook.TimerBook.services.UserService;
-import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
@@ -73,7 +71,6 @@ public class UserController implements UserControllerDocs {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(
-            @Parameter(description = "ID do usuário", example = "1")
             @PathVariable Long id) {
 
         userService.delete(id);
@@ -84,5 +81,24 @@ public class UserController implements UserControllerDocs {
     public ResponseEntity<User> getMe(
             @RequestHeader("Authorization") String authHeader) {
         return ResponseEntity.ok(userService.getMe(authHeader));
+    }
+
+    @GetMapping("/me/reading-goal")
+    public ResponseEntity<UserReadingGoalResponseDTO> getMyReadingGoal(
+            @RequestHeader("Authorization") String authHeader) {
+        Integer goal = userService.getMyReadingGoalMinutes(authHeader);
+        return ResponseEntity.ok(new UserReadingGoalResponseDTO(goal));
+    }
+
+    @PutMapping("/me/reading-goal")
+    public ResponseEntity<UserReadingGoalResponseDTO> updateMyReadingGoal(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestBody UserReadingGoalRequestDTO body) {
+        try {
+            User user = userService.updateMyReadingGoalMinutes(authHeader, body.getDailyReadingGoalMinutes());
+            return ResponseEntity.ok(new UserReadingGoalResponseDTO(user.getDailyReadingGoalMinutes()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 }

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/docs/AuthControllerDocs.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/docs/AuthControllerDocs.java
@@ -35,6 +35,7 @@ public interface AuthControllerDocs {
             @RequestParam("username") String username,
             @RequestParam("email") String email,
             @RequestParam("password") String password,
+            @RequestParam(value = "dailyReadingGoalMinutes", required = false) Integer dailyReadingGoalMinutes,
             MultipartFile photo
     );
     @Operation(summary = "Gerar novo access token usando refresh token")

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/docs/ReadingStatsControllerDocs.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/docs/ReadingStatsControllerDocs.java
@@ -1,6 +1,7 @@
 package com.timerbook.TimerBook.controllers.docs;
 
 import com.timerbook.TimerBook.dto.ReadingStatsDTO;
+import com.timerbook.TimerBook.dto.UserReadingGoalStreakDTO;
 import com.timerbook.TimerBook.models.Reading;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -78,6 +79,23 @@ public interface ReadingStatsControllerDocs {
     })
     public ResponseEntity<Integer> getReadingStreak(
             @Parameter(name = "readingId", required = true, example = "1") @PathVariable Long readingId,
+            @Parameter(name = "start", example = "2026-03-01T00:00:00") @RequestParam(value = "start", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @Parameter(name = "end", example = "2026-03-22T23:59:59") @RequestParam(value = "end", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
+    );
+
+    @Operation(
+            summary = "Obtém streak global do usuário pela meta diária",
+            description = "Retorna streak atual e melhor streak considerando a meta diária configurada pelo usuário."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Streak global retornado com sucesso",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserReadingGoalStreakDTO.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "Não autorizado. Token ausente ou inválido.", content = @Content)
+    })
+    public ResponseEntity<UserReadingGoalStreakDTO> getUserGoalStreak(
             @Parameter(name = "start", example = "2026-03-01T00:00:00") @RequestParam(value = "start", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
             @Parameter(name = "end", example = "2026-03-22T23:59:59") @RequestParam(value = "end", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
     );

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/docs/UserControllerDocs.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/docs/UserControllerDocs.java
@@ -1,15 +1,20 @@
 package com.timerbook.TimerBook.controllers.docs;
 
+import com.timerbook.TimerBook.dto.UserReadingGoalRequestDTO;
+import com.timerbook.TimerBook.dto.UserReadingGoalResponseDTO;
 import com.timerbook.TimerBook.dto.UserDTO;
 import com.timerbook.TimerBook.models.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -63,5 +68,37 @@ public interface UserControllerDocs {
     public ResponseEntity<Void> delete(
             @Parameter(description = "ID do usuário", example = "1")
             @PathVariable Long id);
+
+    @Operation(summary = "Retorna o usuário autenticado")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Usuário autenticado retornado com sucesso"),
+            @ApiResponse(responseCode = "401", description = "Não autorizado", content = @Content)
+    })
+    ResponseEntity<User> getMe(@RequestHeader("Authorization") String authHeader);
+
+    @Operation(summary = "Consulta meta diária de leitura do usuário autenticado")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Meta de leitura retornada com sucesso",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserReadingGoalResponseDTO.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "Não autorizado", content = @Content)
+    })
+    ResponseEntity<UserReadingGoalResponseDTO> getMyReadingGoal(@RequestHeader("Authorization") String authHeader);
+
+    @Operation(summary = "Atualiza meta diária de leitura do usuário autenticado")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Meta atualizada com sucesso",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserReadingGoalResponseDTO.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "Meta inválida", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Não autorizado", content = @Content)
+    })
+    ResponseEntity<UserReadingGoalResponseDTO> updateMyReadingGoal(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestBody UserReadingGoalRequestDTO body);
 
 }

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/RegisterRequestDTO.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/RegisterRequestDTO.java
@@ -1,3 +1,3 @@
 package com.timerbook.TimerBook.dto;
 
-public record RegisterRequestDTO (String username, String email, String password,String photopath){}
+public record RegisterRequestDTO (String username, String email, String password, String photopath, Integer dailyReadingGoalMinutes){}

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/UserDTO.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/UserDTO.java
@@ -15,6 +15,8 @@ public class UserDTO {
     private MultipartFile photopath;
     @Schema(description = "Verifica se tem foto")
     private Boolean  removePhoto;
+    @Schema(description = "Meta diária de leitura em minutos", example = "10")
+    private Integer dailyReadingGoalMinutes;
 
     public String getUsername() {
         return username;
@@ -54,5 +56,13 @@ public class UserDTO {
 
     public void setRemovePhoto(Boolean removePhoto) {
         this.removePhoto = removePhoto;
+    }
+
+    public Integer getDailyReadingGoalMinutes() {
+        return dailyReadingGoalMinutes;
+    }
+
+    public void setDailyReadingGoalMinutes(Integer dailyReadingGoalMinutes) {
+        this.dailyReadingGoalMinutes = dailyReadingGoalMinutes;
     }
 }

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/UserReadingGoalRequestDTO.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/UserReadingGoalRequestDTO.java
@@ -1,0 +1,14 @@
+package com.timerbook.TimerBook.dto;
+
+public class UserReadingGoalRequestDTO {
+
+    private Integer dailyReadingGoalMinutes;
+
+    public Integer getDailyReadingGoalMinutes() {
+        return dailyReadingGoalMinutes;
+    }
+
+    public void setDailyReadingGoalMinutes(Integer dailyReadingGoalMinutes) {
+        this.dailyReadingGoalMinutes = dailyReadingGoalMinutes;
+    }
+}

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/UserReadingGoalResponseDTO.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/UserReadingGoalResponseDTO.java
@@ -1,0 +1,21 @@
+package com.timerbook.TimerBook.dto;
+
+public class UserReadingGoalResponseDTO {
+
+    private Integer dailyReadingGoalMinutes;
+
+    public UserReadingGoalResponseDTO() {
+    }
+
+    public UserReadingGoalResponseDTO(Integer dailyReadingGoalMinutes) {
+        this.dailyReadingGoalMinutes = dailyReadingGoalMinutes;
+    }
+
+    public Integer getDailyReadingGoalMinutes() {
+        return dailyReadingGoalMinutes;
+    }
+
+    public void setDailyReadingGoalMinutes(Integer dailyReadingGoalMinutes) {
+        this.dailyReadingGoalMinutes = dailyReadingGoalMinutes;
+    }
+}

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/UserReadingGoalStreakDTO.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/UserReadingGoalStreakDTO.java
@@ -1,0 +1,50 @@
+package com.timerbook.TimerBook.dto;
+
+public class UserReadingGoalStreakDTO {
+
+    private Integer dailyGoalMinutes;
+    private Long todaySeconds;
+    private Boolean todayGoalReached;
+    private Integer currentStreakDays;
+    private Integer maxStreakDays;
+
+    public Integer getDailyGoalMinutes() {
+        return dailyGoalMinutes;
+    }
+
+    public void setDailyGoalMinutes(Integer dailyGoalMinutes) {
+        this.dailyGoalMinutes = dailyGoalMinutes;
+    }
+
+    public Long getTodaySeconds() {
+        return todaySeconds;
+    }
+
+    public void setTodaySeconds(Long todaySeconds) {
+        this.todaySeconds = todaySeconds;
+    }
+
+    public Boolean getTodayGoalReached() {
+        return todayGoalReached;
+    }
+
+    public void setTodayGoalReached(Boolean todayGoalReached) {
+        this.todayGoalReached = todayGoalReached;
+    }
+
+    public Integer getCurrentStreakDays() {
+        return currentStreakDays;
+    }
+
+    public void setCurrentStreakDays(Integer currentStreakDays) {
+        this.currentStreakDays = currentStreakDays;
+    }
+
+    public Integer getMaxStreakDays() {
+        return maxStreakDays;
+    }
+
+    public void setMaxStreakDays(Integer maxStreakDays) {
+        this.maxStreakDays = maxStreakDays;
+    }
+}

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/models/User.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/models/User.java
@@ -13,6 +13,8 @@ import java.util.Set;
 @Entity
 @Table(name = "users")
 public class User {
+    public static final int DEFAULT_DAILY_READING_GOAL_MINUTES = 10;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -22,6 +24,8 @@ public class User {
     private String photopath;
     private String refreshToken;
     private Boolean enabled = false;
+    @Column(name = "daily_reading_goal_minutes", nullable = false)
+    private Integer dailyReadingGoalMinutes = DEFAULT_DAILY_READING_GOAL_MINUTES;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
@@ -114,15 +118,23 @@ public class User {
         this.refreshToken = refreshToken;
     }
 
+    public Integer getDailyReadingGoalMinutes() {
+        return dailyReadingGoalMinutes;
+    }
+
+    public void setDailyReadingGoalMinutes(Integer dailyReadingGoalMinutes) {
+        this.dailyReadingGoalMinutes = dailyReadingGoalMinutes;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         User user = (User) o;
-        return Objects.equals(id, user.id) && Objects.equals(username, user.username) && Objects.equals(email, user.email) && Objects.equals(password, user.password) && Objects.equals(photopath, user.photopath) && Objects.equals(refreshToken, user.refreshToken) && Objects.equals(enabled, user.enabled) && Objects.equals(books, user.books) && Objects.equals(roles, user.roles);
+        return Objects.equals(id, user.id) && Objects.equals(username, user.username) && Objects.equals(email, user.email) && Objects.equals(password, user.password) && Objects.equals(photopath, user.photopath) && Objects.equals(refreshToken, user.refreshToken) && Objects.equals(enabled, user.enabled) && Objects.equals(dailyReadingGoalMinutes, user.dailyReadingGoalMinutes) && Objects.equals(books, user.books) && Objects.equals(roles, user.roles);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, username, email, password, photopath, refreshToken, enabled, books, roles);
+        return Objects.hash(id, username, email, password, photopath, refreshToken, enabled, dailyReadingGoalMinutes, books, roles);
     }
 }

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/repository/ReadingSessionRepository.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/repository/ReadingSessionRepository.java
@@ -54,4 +54,19 @@ public interface ReadingSessionRepository extends JpaRepository<ReadingSession, 
     List<ReadingSession> findByReadingIdOrderByStartedAtAsc(Long readingId);
 
     List<ReadingSession> findByReadingId(Long readingId);
+
+    @Query(value = "SELECT DATE(rs.started_at) AS day, " +
+            "COALESCE(CAST(SUM(EXTRACT(EPOCH FROM (COALESCE(rs.ended_at, CURRENT_TIMESTAMP) - rs.started_at))) AS BIGINT), 0) AS total_seconds " +
+            "FROM reading_session rs " +
+            "INNER JOIN reading r ON r.id = rs.reading_id " +
+            "WHERE r.user_id = :userId " +
+            "AND rs.started_at BETWEEN :start AND :end " +
+            "GROUP BY DATE(rs.started_at) " +
+            "ORDER BY day ASC",
+            nativeQuery = true)
+    List<Object[]> sumDailyDurationSecondsByUserAndPeriod(
+            @Param("userId") Long userId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/services/AuthService.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/services/AuthService.java
@@ -44,6 +44,9 @@ public class AuthService {
     @Autowired
     private AchievementService achievementService;
 
+    @Autowired
+    private UserService userService;
+
     public ResponseDTO login(LoginRequestDTO body) {
         authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(body.email(), body.password())
@@ -79,6 +82,7 @@ public class AuthService {
         newUser.setUsername(body.username());
         newUser.setEmail(body.email());
         newUser.setPassword(passwordEncoder.encode(body.password()));
+        newUser.setDailyReadingGoalMinutes(userService.normalizeReadingGoal(body.dailyReadingGoalMinutes()));
 
         if (photo != null && !photo.isEmpty()) {
             String photoPath = fileStorageService.storeFile(photo, "profile");

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/services/ReadingStatsService.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/services/ReadingStatsService.java
@@ -1,6 +1,8 @@
 package com.timerbook.TimerBook.services;
 
 import com.timerbook.TimerBook.dto.ReadingStatsDTO;
+import com.timerbook.TimerBook.dto.UserReadingGoalStreakDTO;
+import com.timerbook.TimerBook.models.User;
 import com.timerbook.TimerBook.models.Reading;
 import com.timerbook.TimerBook.models.ReadingSession;
 import com.timerbook.TimerBook.repository.ReadingRepository;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.sql.Date;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -136,6 +139,52 @@ public class ReadingStatsService {
                 .stream()
                 .filter(r -> r.getFinishedAt() == null && r.getUser().getId().equals(userId))
                 .collect(Collectors.toList());
+    }
+
+    public UserReadingGoalStreakDTO getUserGoalStreak(Long userId, LocalDateTime start, LocalDateTime end) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+
+        if (start == null) {
+            start = LocalDateTime.of(2010, 1, 1, 0, 0);
+        }
+        if (end == null) {
+            end = LocalDateTime.now();
+        }
+
+        int goalMinutes = user.getDailyReadingGoalMinutes() == null
+                ? User.DEFAULT_DAILY_READING_GOAL_MINUTES
+                : user.getDailyReadingGoalMinutes();
+
+        long goalSeconds = goalMinutes * 60L;
+        List<Object[]> rows = readingSessionRepository.sumDailyDurationSecondsByUserAndPeriod(userId, start, end);
+
+        Map<LocalDate, Long> dailySecondsByDate = new HashMap<>();
+        for (Object[] row : rows) {
+            Date sqlDate = (Date) row[0];
+            Number totalSeconds = (Number) row[1];
+            dailySecondsByDate.put(sqlDate.toLocalDate(), totalSeconds.longValue());
+        }
+
+        Set<LocalDate> qualifiedDays = dailySecondsByDate.entrySet()
+                .stream()
+                .filter(e -> e.getValue() >= goalSeconds)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        LocalDate endDate = end.toLocalDate();
+        int currentStreak = calculateCurrentStreak(qualifiedDays, endDate);
+        int maxStreak = calculateMaxStreak(qualifiedDays);
+
+        long todaySeconds = dailySecondsByDate.getOrDefault(endDate, 0L);
+
+        UserReadingGoalStreakDTO dto = new UserReadingGoalStreakDTO();
+        dto.setDailyGoalMinutes(goalMinutes);
+        dto.setTodaySeconds(todaySeconds);
+        dto.setTodayGoalReached(todaySeconds >= goalSeconds);
+        dto.setCurrentStreakDays(currentStreak);
+        dto.setMaxStreakDays(maxStreak);
+        return dto;
     }
 
     private int calculateCurrentStreak(Set<LocalDate> daysWithSession, LocalDate endDate) {

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/services/UserService.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/services/UserService.java
@@ -11,8 +11,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Set;
+
 @Service
 public class UserService {
+
+    private static final Set<Integer> ALLOWED_READING_GOALS = Set.of(10, 20, 30);
 
     @Autowired
     private UserRepository userRepository;
@@ -45,6 +49,7 @@ public class UserService {
         user.setEmail(dto.getEmail());
         user.setPassword(passwordEncoder.encode(dto.getPassword()));
         user.setPhotopath(photoPath);
+        user.setDailyReadingGoalMinutes(normalizeReadingGoal(dto.getDailyReadingGoalMinutes()));
 
         Role userRole = roleRepository.findByAuthority("ROLE_USER");
         if (userRole == null) {
@@ -114,5 +119,25 @@ public class UserService {
         String email = decoded.getSubject();
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+    }
+
+    public Integer getMyReadingGoalMinutes(String authHeader) {
+        return getMe(authHeader).getDailyReadingGoalMinutes();
+    }
+
+    public User updateMyReadingGoalMinutes(String authHeader, Integer dailyReadingGoalMinutes) {
+        User user = getMe(authHeader);
+        user.setDailyReadingGoalMinutes(normalizeReadingGoal(dailyReadingGoalMinutes));
+        return userRepository.save(user);
+    }
+
+    public Integer normalizeReadingGoal(Integer goalMinutes) {
+        if (goalMinutes == null) {
+            return User.DEFAULT_DAILY_READING_GOAL_MINUTES;
+        }
+        if (!ALLOWED_READING_GOALS.contains(goalMinutes)) {
+            throw new IllegalArgumentException("Meta de leitura inválida. Valores permitidos: 10, 20 ou 30 minutos.");
+        }
+        return goalMinutes;
     }
 }

--- a/BackEnd/TimerBook_API/src/main/resources/db/migration/V11__add_daily_reading_goal_minutes_to_users.sql
+++ b/BackEnd/TimerBook_API/src/main/resources/db/migration/V11__add_daily_reading_goal_minutes_to_users.sql
@@ -1,0 +1,25 @@
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS daily_reading_goal_minutes INTEGER;
+
+UPDATE users
+SET daily_reading_goal_minutes = 10
+WHERE daily_reading_goal_minutes IS NULL;
+
+ALTER TABLE users
+ALTER COLUMN daily_reading_goal_minutes SET DEFAULT 10;
+
+ALTER TABLE users
+ALTER COLUMN daily_reading_goal_minutes SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_users_daily_reading_goal_minutes'
+    ) THEN
+        ALTER TABLE users
+        ADD CONSTRAINT chk_users_daily_reading_goal_minutes
+        CHECK (daily_reading_goal_minutes IN (10, 20, 30));
+    END IF;
+END $$;

--- a/BackEnd/TimerBook_API/src/main/resources/db/migration/V8__create_table_recovery_password.sql
+++ b/BackEnd/TimerBook_API/src/main/resources/db/migration/V8__create_table_recovery_password.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS password_reset_token (
+    id BIGSERIAL PRIMARY KEY,
+    token VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    user_id BIGINT NOT NULL,
+    CONSTRAINT fk_password_reset_user
+    FOREIGN KEY (user_id)
+    REFERENCES users(id)
+    ON DELETE CASCADE
+);


### PR DESCRIPTION
# 🚀 Meta Diária de Leitura e Streak Global do Usuário

## Visão Geral
Implementação da meta diária de leitura por usuário no backend do TimerBook, permitindo que cada conta defina um objetivo de leitura em minutos por dia. Com essa base, o sistema passa a calcular o streak global do usuário considerando o tempo total lido por dia em todas as leituras vinculadas à conta.

A feature foi desenhada para manter compatibilidade com os fluxos atuais do projeto, sem quebrar os endpoints já existentes de estatísticas por leitura. A nova funcionalidade complementa a camada atual com uma visão consolidada do hábito de leitura do usuário.

## ✨ O que foi entregue

### 🎯 Meta de leitura por usuário
- Adição do campo `daily_reading_goal_minutes` na entidade de usuário.
- Persistência da meta no banco de dados via migration.
- Valor padrão configurado como 10 minutos por dia.
- Validação de valores permitidos: 10, 20 e 30 minutos.

### 🔐 Controle da meta via API
- Novo endpoint para consultar a meta diária do usuário autenticado.
- Novo endpoint para atualizar a meta diária do usuário autenticado.
- Suporte para informar a meta já no cadastro do usuário.
- Resposta padronizada com a meta atual salva no banco.

### 📊 Streak global baseado na meta
- Novo cálculo de streak global do usuário considerando todas as sessões de leitura.
- Um dia só entra na sequência quando a soma total de leitura naquele dia atinge a meta configurada.
- O cálculo leva em conta todas as leituras do usuário, não apenas um livro específico.
- Retorno com métricas consolidadas:
  - meta diária configurada
  - tempo lido hoje
  - status se a meta de hoje foi atingida
  - streak atual
  - maior streak

### 🧱 Integração com a arquitetura existente
- Reaproveitamento da estrutura atual de autenticação e usuário.
- Manutenção dos endpoints antigos de estatísticas por leitura.
- Separação clara entre estatísticas por livro e estatísticas globais por usuário.
- Atualização da documentação dos controllers para refletir os novos contratos.

## ⚙️ Melhorias Técnicas
- Persistência simples e direta no modelo de usuário.
- Validação centralizada no backend para evitar dados inválidos.
- Cálculo de streak baseado em agregação diária no banco.
- Estrutura pronta para evoluir futuramente com metas mais refinadas ou alertas diários.
- Código organizado para manter a feature isolada e de fácil manutenção.

## 📌 Impacto no Projeto
- O usuário passa a ter uma meta diária de leitura configurável.
- O sistema passa a medir consistência real de leitura, não apenas sessões isoladas.
- A base fica pronta para exibir progresso, streak e evolução do hábito de leitura.
- A feature cria a fundação para futuras telas de dashboard e estatísticas gerais.

## 🗃️ Banco de Dados
- Criada migration para adicionar `daily_reading_goal_minutes` na tabela `users`.
- A coluna foi configurada com default 10.
- Foi adicionada restrição para aceitar apenas 10, 20 ou 30 minutos.
- A migration foi versionada como `V11`.

## 📡 Endpoints adicionados
- `GET /user/me/reading-goal`
- `PUT /user/me/reading-goal`
- `GET /stats/user/streak`