### PR TITLE
Estatísticas gerais do usuário

### DIFF
--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/ReadingStatsController.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/ReadingStatsController.java
@@ -56,6 +56,19 @@ public class ReadingStatsController implements ReadingStatsControllerDocs {
         }
     }
 
+    @GetMapping("/user/general")
+    public ResponseEntity<ReadingStatsDTO> getUserGeneralStats(
+            @RequestParam(value = "start", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam(value = "end", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @RequestParam(value = "includeOngoing", required = false, defaultValue = "false") boolean includeOngoing
+    ) {
+        Long userId = getLoggedUserId();
+        ReadingStatsDTO dto = service.getGeneralStatsForUser(userId, start, end, includeOngoing);
+        return ResponseEntity.ok(dto);
+    }
+
     @GetMapping("/reading/{readingId}/streak")
     public ResponseEntity<Integer> getReadingStreak(
             @PathVariable Long readingId,

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/docs/ReadingStatsControllerDocs.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/docs/ReadingStatsControllerDocs.java
@@ -64,6 +64,24 @@ public interface ReadingStatsControllerDocs {
     );
 
     @Operation(
+            summary = "Obtém estatísticas gerais do usuário",
+            description = "Retorna as estatísticas consolidadas de todas as leituras do usuário no período informado."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Estatísticas gerais retornadas com sucesso",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReadingStatsDTO.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "Não autorizado. Token ausente ou inválido.", content = @Content)
+    })
+    public ResponseEntity<ReadingStatsDTO> getUserGeneralStats(
+            @Parameter(name = "start", example = "2026-03-01T00:00:00") @RequestParam(value = "start", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @Parameter(name = "end", example = "2026-03-22T23:59:59") @RequestParam(value = "end", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @Parameter(name = "includeOngoing", example = "false") @RequestParam(value = "includeOngoing", required = false, defaultValue = "false") boolean includeOngoing
+    );
+
+    @Operation(
             summary = "Obtém a sequência atual de uma leitura",
             description = "Retorna apenas quantos dias seguidos você tem lendo este livro."
     )

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/repository/ReadingSessionRepository.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/repository/ReadingSessionRepository.java
@@ -55,6 +55,8 @@ public interface ReadingSessionRepository extends JpaRepository<ReadingSession, 
 
     List<ReadingSession> findByReadingId(Long readingId);
 
+    List<ReadingSession> findByReadingUserIdAndStartedAtBetweenOrderByStartedAtAsc(Long userId, LocalDateTime start, LocalDateTime end);
+
         @Query("SELECT MAX(COALESCE(rs.endedAt, rs.startedAt)) FROM ReadingSession rs WHERE rs.reading.user.id = :userId")
         LocalDateTime findLastReadingActivityAtByUserId(@Param("userId") Long userId);
 

--- a/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/services/ReadingStatsService.java
+++ b/BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/services/ReadingStatsService.java
@@ -11,6 +11,7 @@ import com.timerbook.TimerBook.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.sql.Date;
@@ -132,6 +133,63 @@ public class ReadingStatsService {
         dto.setMaxStreakDays(maxStreak);
         return dto;
 
+    }
+
+    public ReadingStatsDTO getGeneralStatsForUser(Long userId, LocalDateTime start, LocalDateTime end, boolean includeOnGoingSessions) {
+        if (start == null) {
+            start = LocalDateTime.of(2010, 1, 1, 0, 0);
+        }
+        if (end == null) {
+            end = LocalDateTime.now();
+        }
+
+        List<ReadingSession> sessions = readingSessionRepository
+                .findByReadingUserIdAndStartedAtBetweenOrderByStartedAtAsc(userId, start, end);
+
+        int pagesRead = sessions.stream()
+                .filter(rs -> rs.getEndedAt() != null)
+                .filter(rs -> rs.getStartPage() != null && rs.getEndPage() != null)
+                .filter(rs -> rs.getEndPage() >= rs.getStartPage())
+                .mapToInt(rs -> rs.getEndPage() - rs.getStartPage())
+                .sum();
+
+        long totalSeconds = sessions.stream()
+                .mapToLong(rs -> {
+                    if (rs.getStartedAt() == null) {
+                        return 0L;
+                    }
+                    LocalDateTime endedAt = rs.getEndedAt();
+                    if (endedAt == null) {
+                        if (!includeOnGoingSessions) {
+                            return 0L;
+                        }
+                        endedAt = LocalDateTime.now();
+                    }
+                    long seconds = Duration.between(rs.getStartedAt(), endedAt).getSeconds();
+                    return Math.max(seconds, 0L);
+                })
+                .sum();
+
+        long sessionsCount = sessions.size();
+        double avg = (sessionsCount == 0) ? 0.0 : ((double) totalSeconds / (double) sessionsCount);
+
+        Set<LocalDate> daysWithSession = sessions.stream()
+                .filter(rs -> rs.getStartedAt() != null)
+                .map(rs -> rs.getStartedAt().toLocalDate())
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        int currentStreak = calculateCurrentStreak(daysWithSession, end.toLocalDate());
+        int maxStreak = calculateMaxStreak(daysWithSession);
+
+        ReadingStatsDTO dto = new ReadingStatsDTO();
+        dto.setReadingId(null);
+        dto.setPagesRead(pagesRead);
+        dto.setTotalSeconds(totalSeconds);
+        dto.setSessionsCount(sessionsCount);
+        dto.setAverageSecondsPerSession(avg);
+        dto.setCurrentStreakDays(currentStreak);
+        dto.setMaxStreakDays(maxStreak);
+        return dto;
     }
 
     public List<Reading> getReadingsInProgress(Long userId) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     volumes:
       - ./front-end:/app
       - /app/node_modules
-    command: npm run dev -- --host
+    command: sh -c "npm install && npm run dev -- --host"
     depends_on:
       - postgres
 


### PR DESCRIPTION
🚀 Estatísticas Gerais do Usuário

**Visão Geral**  
Implementa estatísticas gerais do usuário agregando dados de todas as leituras e sessões para gerar um resumo único (páginas, tempo, sessões, média e streaks). A solução reutiliza repositórios e DTOs já existentes, expõe um endpoint dedicado e preserva o comportamento atual das consultas por leitura individual.

✨ O que foi entregue

- Agregação de estatísticas por usuário:
  - Soma de páginas lidas (considera sessões finalizadas).
  - Soma de tempo gasto (opção para incluir sessões em andamento).
  - Contagem de sessões e cálculo de média de duração por sessão.
  - Cálculo de streaks: sequência atual e maior sequência de dias com leitura.
- Endpoint HTTP:
  - `GET /stats/user/general` aceita `start`, `end` e `includeOngoing` (mesmo padrão dos endpoints existentes).
- Reaproveitamento/consistência:
  - Mesma estrutura de `ReadingStatsDTO` usada para leituras individuais.
  - Lógica consistente com `getStatsForReading(...)` (mesmas regras de inclusão de sessões e cálculo de streaks).

🗂️ Arquivos / Componentes alterados (principais)
- Serviço: `BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/services/ReadingStatsService.java` — adiciona/contém `getGeneralStatsForUser(...)` com a lógica de agregação.
- Controller: `BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/controllers/ReadingStatsController.java` — adiciona `GET /stats/user/general`.
- DTO: `BackEnd/TimerBook_API/src/main/java/com/timerbook/TimerBook/dto/ReadingStatsDTO.java` — reutilizado para resposta.
- Repository: usa consultas em `ReadingSessionRepository` (consulta por `reading.user.id` ordenada por `startedAt`) — sem mudanças estruturais no esquema de BD.

🧠 Regras e decisões importantes
- Período: se `start`/`end` não forem informados, usa janela ampla até `now()`.
- Sessões em andamento: `includeOngoing` controla se sessões sem `endedAt` contam (usa `LocalDateTime.now()` para cálculo).
- Páginas: só soma quando `startPage` e `endPage` são válidos e `endPage >= startPage`.
- Streaks: calculados por dias com sessão; current/max seguem o mesmo algoritmo do endpoint por leitura.

⚙️ Impacto no projeto
- Não altera tabelas nem dados existentes.  
- Mantém compatibilidade com contratos front-end existentes (mesmo DTO/endpoint análogo).  
- Preparado para otimizações futuras (por exemplo, agregar por usuário via consulta SQL mais eficiente).