### PR TITLE
Incrementando a tela do usuário com estatísticas e gráfico de meta

### DIFF
--- a/front-end/src/features/statistics/reading_stats.js
+++ b/front-end/src/features/statistics/reading_stats.js
@@ -18,3 +18,12 @@ export async function getReadingStreakByReadingId(readingId) {
         throw new Error("Erro ao buscar streak de leitura");
     }
 }
+
+export async function getGeneralStats(){
+    try {
+        const response = await api.get("/stats/user/general");
+        return response.data;
+    } catch (error) {
+        throw new Error("Erro ao buscar estatísticas gerais");
+    }
+}

--- a/front-end/src/pages/Estatisticas.jsx
+++ b/front-end/src/pages/Estatisticas.jsx
@@ -14,9 +14,6 @@ const Estatisticas = () => {
   const [loading, setLoading] = useState(true);
   const [erro, setErro] = useState(null);
 
-  const [isDarkMode, setIsDarkMode] = useState(() => {
-    return localStorage.getItem("timerbook-theme") === "dark";
-  });
 
   //  escuta mudança do tema
   useEffect(() => {
@@ -68,8 +65,6 @@ const Estatisticas = () => {
     return `${hours}h ${minutes}min`;
   };
 
-  // 2. Carrega os estilos baseados no tema atual
-  const styles = getStyles(isDarkMode);
 
   if (loading) return <div style={styles.centerMsg}>Carregando estatísticas...</div>;
   if (erro) return <div style={styles.centerMsg}>{erro}</div>;

--- a/front-end/src/pages/PerfilUsuario.jsx
+++ b/front-end/src/pages/PerfilUsuario.jsx
@@ -1,26 +1,264 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom"; 
-import { useToast } from "../components/ToastContext.js"; 
-import { getUser, deleteUser, updateReadingGoal } from "../features/user/userApi.js"; 
-import { getBookByUserId } from "../features/books/booksApi.js"; 
-import Sidebar from '../components/Sidebar';
-import EditProfileModal from '../components/EditProfileModal';
-import AchievementsList from '../components/AchievementsList'; 
-import ProfileIcon from '../assets/Home/ProfileIcon.svg'; 
-import { getProfilePhotoPath, resolveProfilePhotoUrl } from '../utils/profileImage.js';
+import { useNavigate } from "react-router-dom";
+import { useToast } from "../components/ToastContext.js";
+import { getUser, deleteUser, updateReadingGoal } from "../features/user/userApi.js";
+import { getGeneralStats } from "../features/statistics/reading_stats.js";
+import { getBookByUserId } from "../features/books/booksApi.js";
+import Sidebar from "../components/Sidebar";
+import EditProfileModal from "../components/EditProfileModal";
+import AchievementsList from "../components/AchievementsList";
+import ProfileIcon from "../assets/Home/ProfileIcon.svg";
+import { getProfilePhotoPath, resolveProfilePhotoUrl } from "../utils/profileImage.js";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
 
 import "../styles/PerfilUsuario.css";
-import '../styles/Layout.css'; 
+import "../styles/Layout.css";
+
+function formatSeconds(totalSeconds) {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = Math.round(totalSeconds % 60);
+  if (h > 0) return { value: h, unit: `h ${m}min` };
+  if (m > 0) return { value: m, unit: `min ${s}s` };
+  return { value: s, unit: "s" };
+}
+
+/* ── Custom tooltip for the donut ── */
+function DonutTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const { name, value, unit } = payload[0].payload;
+  return (
+    <div className="donut-tooltip">
+      <p className="donut-tooltip-label">{name}</p>
+      <p className="donut-tooltip-value">{value}{unit ? ` ${unit}` : ""}</p>
+    </div>
+  );
+}
+
+/* ── Custom center label rendered via SVG foreignObject ── */
+function DonutCenter({ cx, cy, totalSeconds, sessionsCount }) {
+  const t = formatSeconds(totalSeconds);
+  return (
+    <g>
+      <text x={cx} y={cy - 10} textAnchor="middle" className="donut-center-value">
+        {t.value}{t.unit}
+      </text>
+      <text x={cx} y={cy + 14} textAnchor="middle" className="donut-center-label">
+        {sessionsCount} sessões
+      </text>
+    </g>
+  );
+}
+
+/* ── Donut chart component ── */
+function GoalDonutChart({ stats, goalMinutes, isDarkMode }) {
+  if (!stats) return null;
+
+  const totalSeconds = stats.totalSeconds || 0;
+  const sessionsCount = stats.sessionsCount || 0;
+  const avgSeconds = Math.round(stats.averageSecondsPerSession || 0);
+  const goalSeconds = (goalMinutes || 10) * 60;
+
+  // Slices: each session represented proportionally by its avg duration
+  // We split total time into: "above avg" sessions vs "below avg" sessions
+  // using a two-slice donut: time read vs remaining to goal
+  const timeRead = Math.min(totalSeconds, goalSeconds);
+  const timeRemaining = Math.max(0, goalSeconds - totalSeconds);
+  const exceeded = totalSeconds > goalSeconds ? totalSeconds - goalSeconds : 0;
+
+  const data = exceeded > 0
+    ? [
+        { name: "Meta cumprida", value: goalSeconds, unit: "s", color: "#1D9E75" },
+        { name: "Além da meta", value: exceeded, unit: "s", color: "#3B6D11" },
+      ]
+    : [
+        { name: "Tempo lido", value: timeRead || 1, unit: "s", color: "#1D9E75" },
+        { name: "Restante para meta", value: timeRemaining || 0, unit: "s", color: isDarkMode ? "#1e2f4c" : "#e2e8f0" },
+      ];
+
+  const pct = goalSeconds > 0 ? Math.min(100, Math.round((totalSeconds / goalSeconds) * 100)) : 0;
+
+  return (
+    <div className={`donut-card ${isDarkMode ? "dark" : ""}`}>
+      <p className="stats-panel-title">Meta de leitura</p>
+
+      <div className="donut-chart-wrap">
+        <ResponsiveContainer width="100%" height={200}>
+          <PieChart>
+            <Pie
+              data={data}
+              cx="50%"
+              cy="50%"
+              innerRadius={62}
+              outerRadius={88}
+              startAngle={90}
+              endAngle={-270}
+              dataKey="value"
+              strokeWidth={0}
+            >
+              {data.map((entry, i) => (
+                <Cell key={i} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip content={<DonutTooltip />} />
+            {/* Center label */}
+            <text x="50%" y="46%" textAnchor="middle" dominantBaseline="middle"
+              style={{ fontSize: 22, fontWeight: 600, fill: isDarkMode ? "#ffffff" : "#1a1a1a" }}>
+              {pct}%
+            </text>
+            <text x="50%" y="58%" textAnchor="middle" dominantBaseline="middle"
+              style={{ fontSize: 11, fill: isDarkMode ? "#64748b" : "#94a3b8" }}>
+              da meta diária
+            </text>
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="donut-legend">
+        {data.map((d, i) => (
+          <div key={i} className="donut-legend-row">
+            <span className="donut-legend-dot" style={{ background: d.color }} />
+            <span className="donut-legend-name">{d.name}</span>
+            <span className="donut-legend-val">{formatSeconds(d.value).value}{formatSeconds(d.value).unit}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="donut-meta-row">
+        <div className="donut-meta-item">
+          <span className="donut-meta-label">Meta diária</span>
+          <span className="donut-meta-value">{goalMinutes || 10} min</span>
+        </div>
+        <div className="donut-meta-item">
+          <span className="donut-meta-label">Média/sessão</span>
+          <span className="donut-meta-value">{avgSeconds}s</span>
+        </div>
+        <div className="donut-meta-item">
+          <span className="donut-meta-label">Sessões</span>
+          <span className="donut-meta-value">{sessionsCount}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Stats panel ── */
+function StatsPanel({ stats, isDarkMode }) {
+  if (!stats) return null;
+
+  const totalTime = formatSeconds(stats.totalSeconds || 0);
+  const avgTime = formatSeconds(stats.averageSecondsPerSession || 0);
+  const streak = stats.currentStreakDays || 0;
+  const maxStreak = stats.maxStreakDays || 0;
+
+  return (
+    <aside className={`stats-panel ${isDarkMode ? "dark" : ""}`}>
+      <p className="stats-panel-title">Estatísticas</p>
+
+      <div className="stat-card">
+        <div className="stat-icon stat-icon--teal">
+          <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path d="M12 20h9M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
+          </svg>
+        </div>
+        <div>
+          <p className="stat-label">Páginas lidas</p>
+          <p className="stat-value">{stats.pagesRead ?? 0}</p>
+        </div>
+      </div>
+
+      <div className="stat-card">
+        <div className="stat-icon stat-icon--blue">
+          <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+          </svg>
+        </div>
+        <div>
+          <p className="stat-label">Tempo total</p>
+          <p className="stat-value">
+            {totalTime.value}<span className="stat-unit">{totalTime.unit}</span>
+          </p>
+        </div>
+      </div>
+
+      <div className="stat-card">
+        <div className="stat-icon stat-icon--amber">
+          <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+          </svg>
+        </div>
+        <div>
+          <p className="stat-label">Média por sessão</p>
+          <p className="stat-value">
+            {avgTime.value}<span className="stat-unit">{avgTime.unit}</span>
+          </p>
+        </div>
+      </div>
+
+      <div className="stat-card">
+        <div className="stat-icon stat-icon--purple">
+          <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <rect x="3" y="4" width="18" height="18" rx="2" />
+            <line x1="16" y1="2" x2="16" y2="6" />
+            <line x1="8" y1="2" x2="8" y2="6" />
+            <line x1="3" y1="10" x2="21" y2="10" />
+          </svg>
+        </div>
+        <div>
+          <p className="stat-label">Sessões</p>
+          <p className="stat-value">{stats.sessionsCount ?? 0}</p>
+        </div>
+      </div>
+
+      <hr className="stats-divider" />
+
+      <div className="stat-card">
+        <div className="stat-icon stat-icon--coral">
+          <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path d="M17 3a2.828 2.828 0 114 4L7.5 20.5 2 22l1.5-5.5L17 3z" />
+          </svg>
+        </div>
+        <div>
+          <p className="stat-label">Sequência atual</p>
+          <div className="stat-streak-row">
+            <span className="stat-value" style={{ fontSize: "16px" }}>{streak}</span>
+            <span className="stat-unit">dias</span>
+          </div>
+          <div className="streak-dots">
+            {Array.from({ length: 7 }, (_, i) => (
+              <span key={i} className={`streak-dot ${i < streak ? "active" : ""}`} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="stat-card">
+        <div className="stat-icon stat-icon--green">
+          <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+          </svg>
+        </div>
+        <div>
+          <p className="stat-label">Melhor sequência</p>
+          <p className="stat-value">
+            {maxStreak}<span className="stat-unit">dias</span>
+          </p>
+        </div>
+      </div>
+    </aside>
+  );
+}
 
 export default function PerfilUsuario() {
   const { showToast } = useToast();
   const [isDarkMode, setIsDarkMode] = useState(() => {
-    const savedTheme = localStorage.getItem('timerbook-theme');
-    return savedTheme === 'dark';
+    const savedTheme = localStorage.getItem("timerbook-theme");
+    return savedTheme === "dark";
   });
 
   const [userInfo, setUserInfo] = useState(null);
   const [books, setBooks] = useState([]);
+  const [generalStats, setGeneralStats] = useState(null);
   const [fetching, setFetching] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -29,26 +267,30 @@ export default function PerfilUsuario() {
   const [savingReadingGoal, setSavingReadingGoal] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
   const [error, setError] = useState(null);
-  
-  const navigate = useNavigate(); 
+
+  const navigate = useNavigate();
 
   useEffect(() => {
-    localStorage.setItem('timerbook-theme', isDarkMode ? 'dark' : 'light');
+    localStorage.setItem("timerbook-theme", isDarkMode ? "dark" : "light");
   }, [isDarkMode]);
 
   useEffect(() => {
     async function fetchData() {
       try {
-        setError(null);
-        const userData = await getUser();
+        const [statsResponse, userData] = await Promise.all([
+          getGeneralStats(),
+          getUser(),
+        ]);
+
+        setGeneralStats(statsResponse?.data || statsResponse);
+
         const info = userData.data || userData;
         setUserInfo(info);
         setSelectedReadingGoal(info.dailyReadingGoalMinutes || 10);
 
-        const userId = info.id;
-        const booksData = await getBookByUserId(userId);
+        const booksData = await getBookByUserId(info.id);
         setBooks(booksData);
-
+        setError(null);
       } catch (err) {
         console.error("Erro ao carregar dados do perfil:", err);
         setError("Não foi possível carregar as informações do seu perfil. Tente atualizar a página.");
@@ -62,7 +304,7 @@ export default function PerfilUsuario() {
   const handleUpdateSuccess = (updatedData) => {
     setUserInfo((prev) => ({ ...prev, ...updatedData }));
     setSuccessMessage("Perfil atualizado com sucesso!");
-    setTimeout(() => setSuccessMessage(""), 4000); 
+    setTimeout(() => setSuccessMessage(""), 4000);
   };
 
   const handleOpenGoalModal = () => {
@@ -72,12 +314,10 @@ export default function PerfilUsuario() {
 
   const handleUpdateReadingGoal = async () => {
     if (!selectedReadingGoal || savingReadingGoal) return;
-
     setSavingReadingGoal(true);
     try {
       const response = await updateReadingGoal(selectedReadingGoal);
       const dailyReadingGoalMinutes = response?.dailyReadingGoalMinutes || selectedReadingGoal;
-
       setUserInfo((prev) => ({ ...prev, dailyReadingGoalMinutes }));
       setSelectedReadingGoal(dailyReadingGoalMinutes);
       setIsGoalModalOpen(false);
@@ -95,11 +335,9 @@ export default function PerfilUsuario() {
     try {
       if (userInfo?.id) {
         await deleteUser(userInfo.id);
-        
-        // Limpa tokens e redireciona para a tela de login
         localStorage.removeItem("token");
         localStorage.removeItem("refreshToken");
-        navigate("/"); 
+        navigate("/");
       }
     } catch (err) {
       console.error("Erro ao excluir conta:", err);
@@ -111,9 +349,9 @@ export default function PerfilUsuario() {
 
   if (fetching) {
     return (
-      <div className={`dashboard-container ${isDarkMode ? 'dark-theme' : ''}`}>
+      <div className={`dashboard-container ${isDarkMode ? "dark-theme" : ""}`}>
         <Sidebar menuAtivo="perfil" books={books} isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
-        <main className="main-content" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        <main className="main-content" style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
           <h2>Carregando perfil...</h2>
         </main>
       </div>
@@ -124,77 +362,81 @@ export default function PerfilUsuario() {
   const profilePhotoUrl = resolveProfilePhotoUrl(profilePhotoPath, { cacheBust: true });
 
   return (
-    <div className={`dashboard-container ${isDarkMode ? 'dark-theme' : ''}`}>
+    <div className={`dashboard-container ${isDarkMode ? "dark-theme" : ""}`}>
       <Sidebar menuAtivo="perfil" books={books} isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
-      
+
       <main className="main-content">
         <h1>Meu Perfil</h1>
 
-        <div className="profile-container">
-          {successMessage && <div className="status-message status-success">✓ {successMessage}</div>}
-          {error && <div className="status-message status-error">✗ {error}</div>}
+        <div className="perfil-layout">
 
-          {userInfo && (
-            <>
-              <div className="info-card">
-                <div className="profile-image-container">
-                  <img 
-                    src={profilePhotoUrl || ProfileIcon} 
-                    alt="Foto" 
-                    className={profilePhotoUrl ? "" : "profile-image-default"}
-                    onError={(e) => {
-                      e.target.onerror = null; 
-                      e.target.src = ProfileIcon;
-                      e.target.className = "profile-image-default";
-                    }}
-                  />
-                </div>
+          {/* Left: profile + achievements + actions */}
+          <div className="perfil-main">
+            <div className="profile-container">
+              {successMessage && <div className="status-message status-success">✓ {successMessage}</div>}
+              {error && <div className="status-message status-error">✗ {error}</div>}
 
-                <div className="profile-details">
-                  <h2>Informações da Conta</h2>
-                  <p><strong>Nome de Usuário:</strong> {userInfo.username}</p>
-                  <p><strong>Email:</strong> {userInfo.email}</p>
-                  <p><strong>Meta diária:</strong> {userInfo.dailyReadingGoalMinutes || 10} minutos</p>
-                </div>
-              </div>
+              {userInfo && (
+                <>
+                  <div className="info-card">
+                    <div className="profile-image-container">
+                      <img
+                        src={profilePhotoUrl || ProfileIcon}
+                        alt="Foto"
+                        className={profilePhotoUrl ? "" : "profile-image-default"}
+                        onError={(e) => {
+                          e.target.onerror = null;
+                          e.target.src = ProfileIcon;
+                          e.target.className = "profile-image-default";
+                        }}
+                      />
+                    </div>
+                    <div className="profile-details">
+                      <h2>Informações da Conta</h2>
+                      <p><strong>Nome de Usuário:</strong> {userInfo.username}</p>
+                      <p><strong>Email:</strong> {userInfo.email}</p>
+                      <p><strong>Meta diária:</strong> {userInfo.dailyReadingGoalMinutes || 10} minutos</p>
+                    </div>
+                  </div>
 
-              {userInfo.id && <AchievementsList userId={userInfo.id} />}
-            </>
-          )}
-        </div>
+                  {userInfo.id && <AchievementsList userId={userInfo.id} />}
+                </>
+              )}
+            </div>
 
-        <div className="bottom-actions" style={{ display: 'flex', gap: '15px', flexWrap: 'wrap' }}>
-          <button className="btn-add-book" onClick={() => setIsModalOpen(true)}>
-            Editar Perfil
-          </button>
+            <div className="bottom-actions" style={{ display: "flex", gap: "15px", flexWrap: "wrap", marginTop: "20px" }}>
+              <button className="btn-add-book" onClick={() => setIsModalOpen(true)}>
+                Editar Perfil
+              </button>
+              <button id="guide-reading-goal-button" className="btn-secondary" onClick={handleOpenGoalModal}>
+                Alterar Meta de Leitura
+              </button>
+              <button className="btn-secondary" onClick={() => navigate("/esqueceu-senha")}>
+                Redefinir Senha
+              </button>
+              <button className="btn-secondary btn-delete-account" onClick={() => setIsDeleteModalOpen(true)}>
+                Deletar Conta
+              </button>
+            </div>
+          </div>
 
-          <button
-            id="guide-reading-goal-button"
-            className="btn-secondary"
-            onClick={handleOpenGoalModal}
-          >
-            Alterar Meta de Leitura
-          </button>
-          
-          <button 
-            className="btn-secondary" 
-            onClick={() => navigate('/esqueceu-senha')}
-          >
-            Redefinir Senha
-          </button>
+          {/* Right column: stats + donut chart */}
+          <div className="perfil-right">
+            <StatsPanel stats={generalStats} isDarkMode={isDarkMode} />
+            <GoalDonutChart
+              stats={generalStats}
+              goalMinutes={userInfo?.dailyReadingGoalMinutes || 10}
+              isDarkMode={isDarkMode}
+            />
+          </div>
 
-          <button 
-            className="btn-secondary btn-delete-account" 
-            onClick={() => setIsDeleteModalOpen(true)}
-          >
-            Deletar Conta
-          </button>
         </div>
       </main>
 
-      <EditProfileModal 
-        isOpen={isModalOpen} 
-        onClose={() => setIsModalOpen(false)} 
+      {/* ── Modals ── */}
+      <EditProfileModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
         userInfo={userInfo}
         onUpdateSuccess={handleUpdateSuccess}
       />
@@ -204,7 +446,6 @@ export default function PerfilUsuario() {
           <div className="reading-goal-modal">
             <h3>Meta diária de leitura</h3>
             <p>Escolha quantos minutos você quer ler por dia.</p>
-
             <div className="reading-goal-options">
               {[10, 20, 30].map((minutes) => (
                 <button
@@ -219,20 +460,11 @@ export default function PerfilUsuario() {
                 </button>
               ))}
             </div>
-
             <div className="reading-goal-actions">
-              <button
-                className="btn-secondary"
-                onClick={() => setIsGoalModalOpen(false)}
-                disabled={savingReadingGoal}
-              >
+              <button className="btn-secondary" onClick={() => setIsGoalModalOpen(false)} disabled={savingReadingGoal}>
                 Cancelar
               </button>
-              <button
-                className="btn-save-goal"
-                onClick={handleUpdateReadingGoal}
-                disabled={savingReadingGoal}
-              >
+              <button className="btn-save-goal" onClick={handleUpdateReadingGoal} disabled={savingReadingGoal}>
                 {savingReadingGoal ? "Salvando..." : "Salvar Meta"}
               </button>
             </div>

--- a/front-end/src/styles/PerfilUsuario.css
+++ b/front-end/src/styles/PerfilUsuario.css
@@ -454,7 +454,7 @@
 .medals-grid {
     display: flex;
     flex-wrap: wrap;
-    gap: 20px;
+    gap: 25px;
 }
 
 .achievement-card-square {
@@ -608,3 +608,354 @@
 .dark-theme .achievement-modal-body p {
     color: #94a3b8;
 }
+
+
+
+
+/* Estilos para as estatísticas */
+/* ─── Profile page layout ────────────────────────────────── */
+.perfil-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.perfil-main {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ─── Stats panel ────────────────────────────────────────── */
+.stats-panel {
+  width: 220px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 20px 16px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05);
+  transition: background-color 0.4s ease, border-color 0.4s ease;
+  position: sticky;
+  top: 24px;
+}
+
+.dark-theme .stats-panel {
+  background-color: #121e31;
+  border-color: #1e2f4c;
+}
+
+.stats-panel-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #94a3b8;
+  margin: 0 0 6px;
+}
+
+.dark-theme .stats-panel-title {
+  color: #64748b;
+}
+
+/* ─── Individual stat card ───────────────────────────────── */
+.stat-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background-color: #f8fafc;
+  border-radius: 10px;
+  padding: 10px 12px;
+  transition: background-color 0.4s ease;
+}
+
+.dark-theme .stat-card {
+  background-color: #0b1221;
+}
+
+.stat-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* Icon color variants */
+.stat-icon--teal  { background-color: #E1F5EE; color: #0F6E56; }
+.stat-icon--blue  { background-color: #E6F1FB; color: #185FA5; }
+.stat-icon--amber { background-color: #FAEEDA; color: #854F0B; }
+.stat-icon--purple{ background-color: #EEEDFE; color: #534AB7; }
+.stat-icon--coral { background-color: #FAECE7; color: #993C1D; }
+.stat-icon--green { background-color: #EAF3DE; color: #3B6D11; }
+
+.stat-label {
+  font-size: 11px;
+  color: #94a3b8;
+  margin: 0 0 2px;
+  line-height: 1;
+}
+
+.dark-theme .stat-label {
+  color: #64748b;
+}
+
+.stat-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a1a;
+  line-height: 1;
+  margin: 0;
+}
+
+.dark-theme .stat-value {
+  color: #ffffff;
+}
+
+.stat-unit {
+  font-size: 11px;
+  font-weight: 400;
+  color: #94a3b8;
+  margin-left: 3px;
+}
+
+.dark-theme .stat-unit {
+  color: #64748b;
+}
+
+.stat-streak-row {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+/* ─── Streak dots ────────────────────────────────────────── */
+.streak-dots {
+  display: flex;
+  gap: 4px;
+  margin-top: 5px;
+}
+
+.streak-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background-color: #e2e8f0;
+  transition: background-color 0.3s ease;
+}
+
+.dark-theme .streak-dot {
+  background-color: #1e2f4c;
+}
+
+.streak-dot.active {
+  background-color: #1D9E75;
+}
+
+/* ─── Divider ────────────────────────────────────────────── */
+.stats-divider {
+  border: none;
+  border-top: 1px solid #e2e8f0;
+  margin: 2px 0;
+}
+
+.dark-theme .stats-divider {
+  border-color: #1e2f4c;
+}
+
+/* ─── Responsive: stack on small screens ─────────────────── */
+@media (max-width: 900px) {
+  .perfil-layout {
+    flex-direction: column;
+  }
+
+  .stats-panel {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 10px;
+    position: static;
+  }
+
+  .stats-panel-title {
+    width: 100%;
+  }
+
+  .stat-card {
+    flex: 1 1 calc(50% - 5px);
+    min-width: 130px;
+  }
+
+  .stats-divider {
+    display: none;
+  }
+}
+
+/* ─── Right column wrapper ───────────────────────────────── */
+.perfil-right {
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  flex-shrink: 0;
+  align-items: flex-start;
+  position: sticky;
+  top: 24px;
+  align-self: flex-start;
+}
+
+.perfil-right .stats-panel {
+  position: static;
+  width: 300px;
+  flex-shrink: 0;
+}
+
+.perfil-right .donut-card {
+  width: 500px;
+  flex-shrink: 0;
+}
+
+/* ─── Donut card ─────────────────────────────────────────── */
+.donut-card {
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 20px 16px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05);
+  transition: background-color 0.4s ease, border-color 0.4s ease;
+}
+
+.dark-theme .donut-card {
+  background-color: #121e31;
+  border-color: #1e2f4c;
+}
+
+.donut-chart-wrap {
+  margin: 8px 0 4px;
+}
+
+/* ─── Legend ─────────────────────────────────────────────── */
+.donut-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.donut-legend-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+}
+
+.donut-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.donut-legend-name {
+  flex: 1;
+  color: #64748b;
+}
+
+.dark-theme .donut-legend-name {
+  color: #94a3b8;
+}
+
+.donut-legend-val {
+  font-weight: 600;
+  color: #1a1a1a;
+  font-size: 12px;
+}
+
+.dark-theme .donut-legend-val {
+  color: #f1f5f9;
+}
+
+/* ─── Meta row ───────────────────────────────────────────── */
+.donut-meta-row {
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid #e2e8f0;
+  padding-top: 12px;
+  gap: 4px;
+}
+
+.dark-theme .donut-meta-row {
+  border-color: #1e2f4c;
+}
+
+.donut-meta-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+}
+
+.donut-meta-label {
+  font-size: 10px;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.dark-theme .donut-meta-label {
+  color: #64748b;
+}
+
+.donut-meta-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.dark-theme .donut-meta-value {
+  color: #ffffff;
+}
+
+/* ─── Tooltip ────────────────────────────────────────────── */
+.donut-tooltip {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+
+.dark-theme .donut-tooltip {
+  background: #121e31;
+  border-color: #1e2f4c;
+}
+
+.donut-tooltip-label {
+  color: #64748b;
+  margin: 0 0 2px;
+}
+
+.donut-tooltip-value {
+  font-weight: 600;
+  color: #1a1a1a;
+  margin: 0;
+}
+
+/* ─── Responsive ─────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .perfil-right {
+    width: 100%;
+    position: static;
+    flex-direction: column;
+  }
+
+  .perfil-right .stats-panel,
+  .perfil-right .donut-card {
+    width: 100%;
+  }
+}
+


### PR DESCRIPTION
## 👤 Perfil do Usuário — Redesign e estatísticas de leitura

### O que foi feito
- Adição de painel lateral de estatísticas com dados de páginas lidas, tempo total, média por sessão, sessões e sequência de dias
- Adição de gráfico donut (via `recharts`) mostrando o progresso do usuário em relação à meta diária de leitura
- Novo layout em três áreas: perfil/conquistas à esquerda, estatísticas à direita e donut na base

### Impacto no produto
- Perfil passa a comunicar progresso de forma visual, aumentando engajamento com metas de leitura
- Usuário consegue acompanhar evolução de hábitos diretamente na tela de perfil, sem navegar para outra página

### Detalhes técnicos
- `Promise.all` para carregar usuário e estatísticas em paralelo, reduzindo tempo de carregamento
- Estilos adicionados com prefixos `stats-`, `stat-`, `donut-` e `perfil-` para evitar conflitos com CSS existente
- Componentes `StatsPanel` e `GoalDonutChart` isolados dentro do próprio arquivo, sem criar novos arquivos de componente
- Nenhuma nova dependência adicionada — `recharts` já estava presente no projeto